### PR TITLE
chore: update paddlejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@paddle/paddle-js": "^1.2.1",
+    "@paddle/paddle-js": "^1.3.1",
     "@paddle/paddle-node-sdk": "^1.5.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     dependencies:
       '@paddle/paddle-js':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.3.1
+        version: 1.3.1
       '@paddle/paddle-node-sdk':
         specifier: ^1.5.0
         version: 1.5.0
@@ -300,9 +300,9 @@ packages:
       { integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg== }
     engines: { node: '>= 8' }
 
-  '@paddle/paddle-js@1.2.1':
+  '@paddle/paddle-js@1.3.1':
     resolution:
-      { integrity: sha512-yvjNrY/msgei/BmRg019giGvtwD+gDUYZpMi7e/4sQbTFrMsRmod/W2ywOVpPhNnxM5ZxZbtTVLCEkdcqZmxYQ== }
+      { integrity: sha512-q2b2aO0dlEPnqiF3dovFIL3QIOwYNbTTPARU9qds9BAnVeUFC9YaKWobfPJaMlKHknPViT0SrAcw+KzA44FNtg== }
 
   '@paddle/paddle-node-sdk@1.5.0':
     resolution:
@@ -3004,7 +3004,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@paddle/paddle-js@1.2.1': {}
+  '@paddle/paddle-js@1.3.1': {}
 
   '@paddle/paddle-node-sdk@1.5.0':
     dependencies:


### PR DESCRIPTION
Bumps `@paddle/paddle-js` version, this is primarily to get the version above `1.2.3` which introduces the inline checkout updates