### PR TITLE
Dependabot 🤖 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '08:00'
+      timezone: 'UTC'
+    open-pull-requests-limit: 10
+    groups:
+      minor-patch-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      major-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+    labels:
+      - 'dependencies'


### PR DESCRIPTION
Adds a `dependabot` config with the following rules:
- run every Monday at 8am
- limit open PRs to a max of 10
- separate PRs for minor and patch updates from major updates (this gives us finer control to test major updates separately)
- add the `dependencies` label to dependabot PRs