### PR TITLE
fix: update anon auth email for supabase

### DIFF
--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -37,7 +37,7 @@ export async function loginAnonymously() {
   const supabase = await createClient();
   const { error: signInError } = await supabase.auth.signInAnonymously();
   const { error: updateUserError } = await supabase.auth.updateUser({
-    email: `anonymous+${Date.now().toString(36)}@example.com`,
+    email: `anonymous+${Date.now().toString(36)}@supabase.io`,
   });
 
   if (signInError || updateUserError) {


### PR DESCRIPTION
Related to issue: https://github.com/PaddleHQ/paddle-nextjs-starter-kit/issues/31

Not entirely sure when/if this changed, but using `example.com` to sign in anonymously no longer works, as mentioned in the related issue and [supabase docs](https://supabase.com/docs/guides/auth/auth-anonymous), updating to `supabase.io` works as expected