### PR TITLE
feat: fix misleading billing cycle display in checkout, added dynamically displayed correct billing cycle text in checkout

### DIFF
--- a/src/components/checkout/checkout-price-container.tsx
+++ b/src/components/checkout/checkout-price-container.tsx
@@ -9,13 +9,17 @@ interface Props {
 
 export function CheckoutPriceContainer({ checkoutData }: Props) {
   const recurringTotal = checkoutData?.recurring_totals?.total;
+  const billingCycle = checkoutData?.items[0]?.billing_cycle?.interval;
+
+  const billingCycleText = billingCycle === 'month' ? 'monthly' : billingCycle === 'year' ? 'yearly' : billingCycle;
+
   return (
     <>
       <div className={'text-base leading-[20px] font-semibold'}>Order summary</div>
       <CheckoutPriceAmount checkoutData={checkoutData} />
       {recurringTotal !== undefined ? (
         <div className={'pt-4 text-base leading-[20px] font-medium text-muted-foreground'}>
-          then {formatMoney(checkoutData?.recurring_totals?.total, checkoutData?.currency_code)} monthly
+          then {formatMoney(recurringTotal, checkoutData?.currency_code)} {billingCycleText}
         </div>
       ) : (
         <Skeleton className="mt-4 h-[20px] w-full bg-border" />


### PR DESCRIPTION
feat: fix misleading billing cycle display in checkout, added dynamically displayed correct billing cycle text in checkout

Problem:
- Billing cycle text was hardcoded to "monthly" regardless of the selected plan
- Customers selecting yearly plans saw confusing "then x amount monthly" text
- Code created a recurringTotal variable but didn't use it consistently

Solution:
- Added logic to dynamically display "monthly" or "yearly" based on checkout data
- Removed redundant code and consistently used the stored variable
- Updated the recurring total display to correctly reflect the billing cycle
- Improved checkout clarity and accuracy for customers on annual plans