### PR TITLE
feat: Fixed billing cycle display in checkout screen

### DIFF
--- a/src/components/checkout/checkout-price-container.tsx
+++ b/src/components/checkout/checkout-price-container.tsx
@@ -2,6 +2,7 @@ import { CheckoutPriceAmount } from '@/components/checkout/checkout-price-amount
 import { CheckoutEventsData } from '@paddle/paddle-js/types/checkout/events';
 import { formatMoney } from '@/utils/paddle/parse-money';
 import { Skeleton } from '@/components/ui/skeleton';
+import { formatBillingCycle } from '@/utils/paddle/data-helpers';
 
 interface Props {
   checkoutData: CheckoutEventsData | null;
@@ -9,14 +10,17 @@ interface Props {
 
 export function CheckoutPriceContainer({ checkoutData }: Props) {
   const recurringTotal = checkoutData?.recurring_totals?.total;
+  const billingCycle = checkoutData?.items.find((item) => item.billing_cycle)?.billing_cycle;
   return (
     <>
       <div className={'text-base leading-[20px] font-semibold'}>Order summary</div>
       <CheckoutPriceAmount checkoutData={checkoutData} />
       {recurringTotal !== undefined ? (
-        <div className={'pt-4 text-base leading-[20px] font-medium text-muted-foreground'}>
-          then {formatMoney(checkoutData?.recurring_totals?.total, checkoutData?.currency_code)} monthly
-        </div>
+        billingCycle && (
+          <div className={'pt-4 text-base leading-[20px] font-medium text-muted-foreground'}>
+            then {formatMoney(recurringTotal, checkoutData?.currency_code)} {formatBillingCycle(billingCycle)}
+          </div>
+        )
       ) : (
         <Skeleton className="mt-4 h-[20px] w-full bg-border" />
       )}

--- a/src/utils/paddle/data-helpers.ts
+++ b/src/utils/paddle/data-helpers.ts
@@ -1,3 +1,5 @@
+import { CheckoutEventsTimePeriod } from '@paddle/paddle-js';
+
 export function parseSDKResponse<T>(response: T): T {
   return JSON.parse(JSON.stringify(response));
 }
@@ -13,5 +15,27 @@ export function getPaymentReason(origin: string) {
     return 'New';
   } else {
     return 'Renewal of ';
+  }
+}
+
+const BillingCycleMap = {
+  day: 'daily',
+  week: 'weekly',
+  month: 'monthly',
+  year: 'yearly',
+};
+
+const CustomBillingCycleMap = {
+  day: 'days',
+  week: 'weeks',
+  month: 'months',
+  year: 'years',
+};
+
+export function formatBillingCycle({ frequency, interval }: CheckoutEventsTimePeriod) {
+  if (frequency === 1) {
+    return BillingCycleMap[interval];
+  } else {
+    return `every ${frequency} ${CustomBillingCycleMap[interval]}`;
   }
 }


### PR DESCRIPTION
Fixed a bug related to `billingCycle` in the checkout screen. Earlier it was hardcoded to `monthly` which is incorrect. 

Updated the code to read the cycle from checkout items and format the value to a human readable form.

Supersedes: #36 