### PR TITLE
Throw error for webhook failures

### DIFF
--- a/src/utils/paddle/process-webhook.ts
+++ b/src/utils/paddle/process-webhook.ts
@@ -23,38 +23,32 @@ export class ProcessWebhook {
   }
 
   private async updateSubscriptionData(eventData: SubscriptionCreatedEvent | SubscriptionUpdatedEvent) {
-    try {
-      const supabase = await createClient();
-      const response = await supabase
-        .from('subscriptions')
-        .upsert({
-          subscription_id: eventData.data.id,
-          subscription_status: eventData.data.status,
-          price_id: eventData.data.items[0].price?.id ?? '',
-          product_id: eventData.data.items[0].price?.productId ?? '',
-          scheduled_change: eventData.data.scheduledChange?.effectiveAt,
-          customer_id: eventData.data.customerId,
-        })
-        .select();
-      console.log(response);
-    } catch (e) {
-      console.error(e);
-    }
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from('subscriptions')
+      .upsert({
+        subscription_id: eventData.data.id,
+        subscription_status: eventData.data.status,
+        price_id: eventData.data.items[0].price?.id ?? '',
+        product_id: eventData.data.items[0].price?.productId ?? '',
+        scheduled_change: eventData.data.scheduledChange?.effectiveAt,
+        customer_id: eventData.data.customerId,
+      })
+      .select();
+
+    if (error) throw error;
   }
 
   private async updateCustomerData(eventData: CustomerCreatedEvent | CustomerUpdatedEvent) {
-    try {
-      const supabase = await createClient();
-      const response = await supabase
-        .from('customers')
-        .upsert({
-          customer_id: eventData.data.id,
-          email: eventData.data.email,
-        })
-        .select();
-      console.log(response);
-    } catch (e) {
-      console.error(e);
-    }
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from('customers')
+      .upsert({
+        customer_id: eventData.data.id,
+        email: eventData.data.email,
+      })
+      .select();
+
+    if (error) throw error;
   }
 }


### PR DESCRIPTION
## Description

We need to return a 500 when we can't process the webhook properly, so that Paddle will retry the notification

## Changes

- It doesn't look like the supabase `upsert` throws an error, it just returns it as part of the response, so we'll throw it ourselves to let the API route handle it
- Update the return for the webhook route to set the status of the response correctly, previously it was setting it as part of the data rather than the options, so you would see something like:
```
{ status: 500, eventName: "subscription.created" }
```
But it would still return a 200. See https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static for `Response.json` usage