### PR TITLE
Add support for wechat pay

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See it in action: [https://paddle-billing.vercel.app/](https://paddle-billing.ve
 ## Features
 
 - Three-tier pricing page that's fully localized for 200+ markets using [Paddle.js](https://developer.paddle.com/paddlejs/overview).
-- An integrated checkout experience built with [Paddle Checkout](https://developer.paddle.com/concepts/sell/self-serve-checkout), with secure [optimized payments](https://developer.paddle.com/concepts/payment-methods/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) by card, Apple Pay, Google Pay, PayPal, and others.
+- An integrated checkout experience built with [Paddle Checkout](https://developer.paddle.com/concepts/sell/self-serve-checkout), with secure [optimized payments](https://developer.paddle.com/concepts/payment-methods/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) by card, Apple Pay, Google Pay, PayPal, [WeChat Pay](https://developer.paddle.com/concepts/payment-methods/wechat-pay), and others.
 - User management and auth handled by [Supabase](https://supabase.com/).
 - Ready-made screens to let customers manage their payments and subscriptions.
 - Automatic syncing of customer and subscription data between Paddle and your app using [webhooks](https://developer.paddle.com/webhooks/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit).
@@ -127,6 +127,15 @@ You must add URLs to Paddle before you can launch a checkout from them. This pro
 3. Go to [**Paddle > Developer tools > Notifications**](https://sandbox-vendors.paddle.com/notifications), then check that the endpoint URL matches your Vercel demo app link domain.
 
 > **Important:** Website approval is instant for sandbox accounts, but may take a little while for live accounts while the Paddle seller verification team check your website.
+
+#### Enable WeChat Pay (optional)
+
+To accept [WeChat Pay](https://developer.paddle.com/concepts/payment-methods/wechat-pay) for customers in China:
+
+1. Go to [**Paddle > Checkout > Checkout settings**](https://sandbox-vendors.paddle.com/checkout-settings).
+2. On the **General** tab, check **WeChat Pay** and click **Save**.
+
+WeChat Pay is shown automatically when the customer’s country is China and the price is in **CNY** or **USD**. Ensure you have [prices in CNY or USD](https://developer.paddle.com/build/products/create-products-prices?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) in your Paddle catalog for the Chinese market. On desktop, customers scan a QR code with the WeChat app; no code changes are required in this repo. You don’t need a WeChat Pay account or an entity in China.
 
 #### Test
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See it in action: [https://paddle-billing.vercel.app/](https://paddle-billing.ve
 ## Features
 
 - Three-tier pricing page that's fully localized for 200+ markets using [Paddle.js](https://developer.paddle.com/paddlejs/overview).
-- An integrated checkout experience built with [Paddle Checkout](https://developer.paddle.com/concepts/sell/self-serve-checkout), with secure [optimized payments](https://developer.paddle.com/concepts/payment-methods/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) by card, Apple Pay, Google Pay, PayPal, [WeChat Pay](https://developer.paddle.com/concepts/payment-methods/wechat-pay), and others.
+- An integrated checkout experience built with [Paddle Checkout](https://developer.paddle.com/concepts/sell/self-serve-checkout), with secure [optimized payments](https://developer.paddle.com/concepts/payment-methods/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) by card, Apple Pay, Google Pay, PayPal, and others.
 - User management and auth handled by [Supabase](https://supabase.com/).
 - Ready-made screens to let customers manage their payments and subscriptions.
 - Automatic syncing of customer and subscription data between Paddle and your app using [webhooks](https://developer.paddle.com/webhooks/overview?utm_source=dx&utm_medium=paddle-nextjs-starter-kit).
@@ -127,15 +127,6 @@ You must add URLs to Paddle before you can launch a checkout from them. This pro
 3. Go to [**Paddle > Developer tools > Notifications**](https://sandbox-vendors.paddle.com/notifications), then check that the endpoint URL matches your Vercel demo app link domain.
 
 > **Important:** Website approval is instant for sandbox accounts, but may take a little while for live accounts while the Paddle seller verification team check your website.
-
-#### Enable WeChat Pay (optional)
-
-To accept [WeChat Pay](https://developer.paddle.com/concepts/payment-methods/wechat-pay) for customers in China:
-
-1. Go to [**Paddle > Checkout > Checkout settings**](https://sandbox-vendors.paddle.com/checkout-settings).
-2. On the **General** tab, check **WeChat Pay** and click **Save**.
-
-WeChat Pay is shown automatically when the customer’s country is China and the price is in **CNY** or **USD**. Ensure you have [prices in CNY or USD](https://developer.paddle.com/build/products/create-products-prices?utm_source=dx&utm_medium=paddle-nextjs-starter-kit) in your Paddle catalog for the Chinese market. On desktop, customers scan a QR code with the WeChat app; no code changes are required in this repo. You don’t need a WeChat Pay account or an entity in China.
 
 #### Test
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@paddle/paddle-js": "^1.5.1",
-    "@paddle/paddle-node-sdk": "^3.4.0",
+    "@paddle/paddle-js": "^1.6.2",
+    "@paddle/paddle-node-sdk": "^3.6.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
   .:
     dependencies:
       '@paddle/paddle-js':
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.6.2
+        version: 1.6.2
       '@paddle/paddle-node-sdk':
-        specifier: ^3.4.0
-        version: 3.4.0
+        specifier: ^3.6.0
+        version: 3.6.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
@@ -442,11 +442,11 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@paddle/paddle-js@1.5.1':
-    resolution: {integrity: sha512-n5btAxhRt3ws0/7g8tlz5yH1kYbN3DRp4pKQD5F2hueovmn6rasxrlJJgd33+dI9amA2w2OjkV+mxuori4eEJA==}
+  '@paddle/paddle-js@1.6.2':
+    resolution: {integrity: sha512-nx1NXCzwWUWjf0iaRDiXZlfWgFjNZ6996RFcTDk0G0ggzrh514Zsc6jGTPOUGdLB1sYJXVQiKKoNLoKoXhH+sA==}
 
-  '@paddle/paddle-node-sdk@3.4.0':
-    resolution: {integrity: sha512-oBgUo9o2PbVP5GUpLOzWtq9gYQqLzIVZ/gav7PqzrlC/9qRcNagOQ63kD050f3ts8+iSvONqiclMAWGF1aOGEA==}
+  '@paddle/paddle-node-sdk@3.6.0':
+    resolution: {integrity: sha512-EFP1thHb1FVuKGwSJ/+/oj5FvCk3l3adyVy/mpUnDq/MM31RdcAdNn+AZ8qYd0pF4rJxtwXmWMGjXqjHKhKHuA==}
     engines: {node: '>=20'}
 
   '@radix-ui/number@1.1.1':
@@ -2864,9 +2864,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@paddle/paddle-js@1.5.1': {}
+  '@paddle/paddle-js@1.6.2': {}
 
-  '@paddle/paddle-node-sdk@3.4.0': {}
+  '@paddle/paddle-node-sdk@3.6.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4008,7 +4008,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4030,7 +4030,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/dashboard/subscriptions/components/payment-method-details.tsx
+++ b/src/components/dashboard/subscriptions/components/payment-method-details.tsx
@@ -20,6 +20,7 @@ const PaymentMethodLabels: Record<PaddlePaymentMethodDetails['type'], string> = 
   pix: 'Pix',
   samsung_pay: 'Samsung Pay',
   upi: 'UPI',
+  wechat_pay: 'WeChat Pay',
   offline: 'Offline',
   unknown: 'Unknown',
 };


### PR DESCRIPTION
# Add WeChat Pay support

## Summary

Documents how to enable [WeChat Pay](https://developer.paddle.com/concepts/payment-methods/wechat-pay) in the starter kit and bumps Paddle dependencies. No application code changes are required (other than a type addition), Paddle Billing already supports WeChat Pay. Enabling it in the Paddle dashboard is sufficient.