### PR TITLE
Scope subscription access and RLS policies to the authenticated user

### DIFF
--- a/src/app/dashboard/subscriptions/actions.ts
+++ b/src/app/dashboard/subscriptions/actions.ts
@@ -4,6 +4,7 @@ import { validateUserSession } from '@/utils/supabase/server';
 import { Subscription } from '@paddle/paddle-node-sdk';
 import { revalidatePath } from 'next/cache';
 import { getPaddleInstance } from '@/utils/paddle/get-paddle-instance';
+import { getCustomerId } from '@/utils/paddle/get-customer-id';
 
 const paddle = getPaddleInstance();
 
@@ -15,11 +16,19 @@ export async function cancelSubscription(subscriptionId: string): Promise<Subscr
   try {
     await validateUserSession();
 
-    const subscription = await paddle.subscriptions.cancel(subscriptionId, { effectiveFrom: 'next_billing_period' });
-    if (subscription) {
+    const customerId = await getCustomerId();
+    const subscription = await paddle.subscriptions.get(subscriptionId);
+    if (!customerId || subscription.customerId !== customerId) {
+      return { error: 'Something went wrong, please try again later' };
+    }
+
+    const canceledSubscription = await paddle.subscriptions.cancel(subscriptionId, {
+      effectiveFrom: 'next_billing_period',
+    });
+    if (canceledSubscription) {
       revalidatePath('/dashboard/subscriptions');
     }
-    return JSON.parse(JSON.stringify(subscription));
+    return JSON.parse(JSON.stringify(canceledSubscription));
   } catch (e) {
     console.log('Error canceling subscription', e);
     return { error: 'Something went wrong, please try again later' };

--- a/src/utils/paddle/get-subscription.ts
+++ b/src/utils/paddle/get-subscription.ts
@@ -13,6 +13,10 @@ export async function getSubscription(subscriptionId: string): Promise<Subscript
         include: ['next_transaction', 'recurring_transaction_details'],
       });
 
+      if (subscription.customerId !== customerId) {
+        return { error: ErrorMessage };
+      }
+
       return { data: parseSDKResponse(subscription) };
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/supabase/migrations/20260721000000_restrict_read_policies.sql
+++ b/supabase/migrations/20260721000000_restrict_read_policies.sql
@@ -1,0 +1,32 @@
+-- Ensure row level security is enforced on billing tables
+alter table "public"."customers" enable row level security;
+
+alter table "public"."subscriptions" enable row level security;
+
+-- Replace the permissive read policies that exposed all rows to any authenticated user
+drop policy if exists "Enable read access for authenticated users to customers" on "public"."customers";
+
+drop policy if exists "Enable read access for authenticated users to subscriptions" on "public"."subscriptions";
+
+-- Authenticated users can only read the customer row matching their own email
+create policy "Enable users to read their own customer record" on "public"."customers" as PERMISSIVE for SELECT to authenticated using (
+  (
+    select
+      auth.jwt () ->> 'email'
+  ) = email
+);
+
+-- Authenticated users can only read subscriptions linked to their own customer record
+create policy "Enable users to read their own subscriptions" on "public"."subscriptions" as PERMISSIVE for SELECT to authenticated using (
+  customer_id in (
+    select
+      customer_id
+    from
+      public.customers
+    where
+      email = (
+        select
+          auth.jwt () ->> 'email'
+      )
+  )
+);


### PR DESCRIPTION
## Ticket

DX-1020

## Reason for change

The Supabase `SELECT` policies on `customers` and `subscriptions` used `using (true)`, letting any authenticated user read every customer's email and subscription rows via the Supabase REST API. `cancelSubscription` and `getSubscription` accepted any subscription ID without checking ownership, so an authenticated user could cancel or view another user's subscription.

## What has been done

- New migration scopes the read policies to the caller's own customer record and explicitly enables RLS on both tables.
- `cancelSubscription` and `getSubscription` now verify the subscription belongs to the authenticated user's Paddle customer before acting.

Existing deployments need the new migration applied manually — redeploying the app does not touch the database.

## How to test

1. Sign in as user A with an active subscription; confirm the dashboard still lists and cancels their own subscription.
2. Sign in as user B and call `cancelSubscription`/`getSubscription` with user A's subscription ID — both return a generic error.
3. As user B, query `/rest/v1/customers` and `/rest/v1/subscriptions` with the anon key and user B's access token — only user B's rows are returned.
